### PR TITLE
Update label handling in tfrecord

### DIFF
--- a/roadart/lib/src/labeler.dart
+++ b/roadart/lib/src/labeler.dart
@@ -105,6 +105,13 @@ class Labeler {
         frameIndex: frameIndex,
         outputPath: kSegmentPath));
     final LineFilter maskLabel = await labelGeneral(kSegmentPath, modelPath);
+
+    // Copy the mask line detection for debugging.
+    final lineFile = File('/tmp/line_detection.png');
+    if (lineFile.existsSync()) {
+      lineFile.copySync('/tmp/line_detection_sam.png');
+    }
+
     final LineFilter label = await _handleRequest(pb.LineRequest(
         videoPath: videoPath, frameIndex: frameIndex, modelPath: modelPath));
     return await labelAfterMask(maskLabel, label);

--- a/roadpy/make_tfrecord.py
+++ b/roadpy/make_tfrecord.py
@@ -55,9 +55,11 @@ def process_label_result(
                         json_map["yRatio"],
                         json_map["leftRatio"],
                         json_map["rightRatio"],
+                        json_map["yRatioObstacleMin"],
                         json_map["yRatioObstacleMax"],
                         json_map["xRatioObstacleMin"],
                         json_map["xRatioObstacleMax"],
+                        json_map["obstacleConfidence"],
                     ]
                 )
             ),

--- a/roadpy/tfrecord_utils.py
+++ b/roadpy/tfrecord_utils.py
@@ -103,9 +103,9 @@ def draw_label(image_bgr, label, point_color=(0, 0, 255), line_color=(255, 0, 0)
         thickness=2,
     )
 
-    obs_b = label[4] * IMAGE_H
-    obs_l = label[5] * IMAGE_W
-    obs_r = label[6] * IMAGE_W
+    obs_b = label[5] * IMAGE_H
+    obs_l = label[6] * IMAGE_W
+    obs_r = label[7] * IMAGE_W
     cv2.line(
         image_bgr,
         (int(obs_l), int(obs_b)),

--- a/roadpy/tfrecord_utils.py
+++ b/roadpy/tfrecord_utils.py
@@ -7,6 +7,7 @@ import keras  # noqa: E402
 import tensorflow as tf  # noqa: E402
 
 
+LABEL_SIZE = 9
 IMAGE_W = 320  # 640
 IMAGE_H = 240  # 360
 
@@ -103,16 +104,17 @@ def draw_label(image_bgr, label, point_color=(0, 0, 255), line_color=(255, 0, 0)
         thickness=2,
     )
 
-    obs_b = label[5] * IMAGE_H
-    obs_l = label[6] * IMAGE_W
-    obs_r = label[7] * IMAGE_W
-    cv2.line(
-        image_bgr,
-        (int(obs_l), int(obs_b)),
-        (int(obs_r), int(obs_b)),
-        (0, 255, 0),  # Green
-        thickness=2,
-    )
+    if label.shape[0] >= LABEL_SIZE - 1:
+        obs_b = label[5] * IMAGE_H
+        obs_l = label[6] * IMAGE_W
+        obs_r = label[7] * IMAGE_W
+        cv2.line(
+            image_bgr,
+            (int(obs_l), int(obs_b)),
+            (int(obs_r), int(obs_b)),
+            (0, 255, 0),  # Green
+            thickness=2,
+        )
 
 
 # Return a new bgr image with the prediction lines

--- a/roadpy/train.py
+++ b/roadpy/train.py
@@ -4,6 +4,7 @@ import glob
 import cv2
 
 from tfrecord_utils import (
+    LABEL_SIZE,
     IMAGE_W,
     IMAGE_H,
     TFRECORD_PATH,
@@ -18,7 +19,6 @@ os.environ["KERAS_BACKEND"] = "jax"
 import tensorflow as tf  # noqa: E402
 import keras  # noqa: E402
 
-LABEL_SIZE = 9
 IGNORE_LEFT = True
 
 print(f"keras backend: {keras.backend.backend()}")

--- a/roadpy/train.py
+++ b/roadpy/train.py
@@ -18,18 +18,18 @@ os.environ["KERAS_BACKEND"] = "jax"
 import tensorflow as tf  # noqa: E402
 import keras  # noqa: E402
 
+LABEL_SIZE = 9
 IGNORE_LEFT = True
 
 print(f"keras backend: {keras.backend.backend()}")
 
 dataset = tf.data.TFRecordDataset(TFRECORD_PATH)
 
-
 # The decoded png has a BGR format.
 def decode_png(example):
     features = {
         "image": tf.io.FixedLenFeature([], tf.string),
-        "label": tf.io.FixedLenFeature([4], tf.float32),
+        "label": tf.io.FixedLenFeature([LABEL_SIZE], tf.float32),
     }
     example = tf.io.parse_single_example(example, features)
     image = tf.image.decode_png(example["image"], channels=3)
@@ -37,8 +37,10 @@ def decode_png(example):
     return image, example["label"]
 
 
-def bgr_to_input(image, label):
-    return bgr_to_rgb(image), tf.multiply(label, [1, 1, 0 if IGNORE_LEFT else 1, 1])
+def bgr_to_input(image, label: tf.Tensor):
+    # TODO: use obstacle labels (labels[4:9])
+    sliced = label[:4]
+    return bgr_to_rgb(image), tf.multiply(sliced, [1, 1, 0 if IGNORE_LEFT else 1, 1])
 
 
 def load_dataset_rgb_int8(check: bool = False):


### PR DESCRIPTION
A few more obstacle labels are now added and handled. They are still unused in training. But we fixed the size/dimension so we can correctly load them.