### PR TITLE
Specify jax to use CUDA in Linux

### DIFF
--- a/roadpy/pyproject.toml
+++ b/roadpy/pyproject.toml
@@ -8,7 +8,8 @@ version = "0.0.1"
 dependencies = [
   "grpcio",
   "grpcio-tools",
-  "jax",
+  "jax[cuda12]; sys_platform == 'linux'",
+  "jax; sys_platform == 'darwin'",
   "kaleido",
   "keras",
   "opencv-python",


### PR DESCRIPTION
Without it, the jax will default to use CPU, and the training will be very slow (5s vs 30ms).
We could still use CPU jax on MacOS.