### PR TITLE
Pin torch to 2.1.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,15 +14,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
 
-      - name: Set up Python
+      - name: Install Python packages
         working-directory: roadpy
         run: |
           sh shortcut/init_env.sh
           source ./environment/bin/activate
+          python --version
           pip install -e .
 
       - name: Compile proto

--- a/roadpy/pyproject.toml
+++ b/roadpy/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
   "plotly",
   "segment-anything @ git+https://github.com/facebookresearch/segment-anything.git",
   "tensorflow",
-  "torch",
+  "torch==2.1.2",
   "torchvision",
   "transformers",
   "wget",


### PR DESCRIPTION
The latest stable version 2.5.1 seems to have a lot of issues with CUDA. I wasn't able to make it work after a whole afternoon. So let's pin it to an earlier version as a short-term solution.